### PR TITLE
fix: damage display in easy battle

### DIFF
--- a/HP Cost for Weapons and Items/hpcost-alias.js
+++ b/HP Cost for Weapons and Items/hpcost-alias.js
@@ -99,21 +99,16 @@
 
     // Now calls startDamageAnimation even in the event of a miss, to account for self-harm.
     // The two below functions reduce the HP gauge during easy battle.
+    var alias29 = EasyMapUnit._startDamage;
     EasyMapUnit._startDamage = function () {
-        this._doHitAction();
-
+        alias29.call(this);
         this._easyBattle.startDamageAnimation();
-        if (this._order.isCurrentHit()) {
-            this._showDamageAnime();
-        }
-        else {
-            this._showAvoidAnime();
-            this.changeCycleMode(MapUnitMode.AVOID_FORWARD);
-        }
-
-        this._attackEffect = null;
     }
+    var alias30 = EasyBattle.startDamageAnimation;
     EasyBattle.startDamageAnimation = function () {
+        // NOTE: alias30.call isn't actually doing anything; later calls of startDamageAnimation seem to override earlier calls. 
+        // The purpose of this alias is only for compatibility with any other plugins adding new functionality to startDamageAnimation.
+        alias30.call(this);
         var order = this._order;
         var damageActive;
         var damagePassive = order.getPassiveDamage() * -1;

--- a/HP Cost for Weapons and Items/hpcost-control.js
+++ b/HP Cost for Weapons and Items/hpcost-control.js
@@ -1,11 +1,11 @@
-//Plugin by Goinza
+// Plugin by Goinza
 
 var HPCostControl = {
 
-    hasCost: function(item) {
+    hasCost: function (item) {
         var lifeCost = 0;
-        if (item !=null && item.custom.lifeCost!=null) {
-            if (typeof item.custom.lifeCost != 'number') {
+        if (item && item.custom.lifeCost) {
+            if (typeof item.custom.lifeCost !== 'number') {
                 throwError029(item);
             }
             lifeCost = item.custom.lifeCost;
@@ -14,23 +14,23 @@ var HPCostControl = {
         return lifeCost;
     },
 
-    //Returns a number that represent the max amount of times it can use the item with the unit's current HP
-    //It assumes that the chech for the lifeCost parameter has been done
-    getTimesPayCost: function(unit, item) {
+    // Returns a number that represents the max amount of times the unit can use the item with the unit's current HP
+    // Assumes that the check for the lifeCost parameter has been done
+    getTimesPayCost: function (unit, item) {
         var lifeCost = item.custom.lifeCost;
-        var maxUseCount = Math.floor(unit.getHp()/lifeCost); 
+        var maxUseCount = Math.floor(unit.getHp() / lifeCost);
 
         return maxUseCount;
     },
 
-    //It assumes that the chech for the lifeCost parameter has been done
-    canPayCost: function(unit, item) {
-        return this.getTimesPayCost(unit, item)>=1;
+    // Assumes that the check for the lifeCost parameter has been done
+    canPayCost: function (unit, item) {
+        return this.getTimesPayCost(unit, item) >= 1;
     },
 
-    //Deals damage to the unit according to the amount of cost it takes from the item
-    //It also assumes that the unit's current HP is greater than the damage done by the item
-    payLife: function(unit, item) {
+    // Deals damage to the unit according to the amount of cost it takes from the item
+    // Assumes that the unit's current HP is greater than the damage done by the item
+    payLife: function (unit, item) {
         if (this.hasCost(item)) {
             var currentHP = unit.getHp();
             var lifeCost = item.custom.lifeCost;


### PR DESCRIPTION
HP Costs now correctly display in easy battle. Adds 4 functions to `hpcost-alias.js`: one new, three aliased.

Also included are cleanliness/typo fixes and removal of some redundant code, such as overly explicit null checks and a call to HPCostControl.hasCost with no argument (which only worked because the if statement using that condition had no curly braces, lucky lucky!).