### PR TITLE
added teaching items

### DIFF
--- a/Combat Art/$readme.txt
+++ b/Combat Art/$readme.txt
@@ -101,6 +101,17 @@ If you want to assign (or remove) a combat art to an unit during an event, you n
             -"Add": This will add the combat art to the unit.
             -"Remove": This will remove the combat art from the unit.
 
+CREATE AN ITEM THAT TEACHES THE USER A COMBAT ART
+You can create consumable items that, when used, will teach the unit a specific combat art. 
+You can also define the prerequisite weapon category for the combat art, for example a bow art that a mage shouldn't be able to learn.
+    - Create an item of type Custom with the keyword "CAItem".
+    - Add custom parameters to define the combat art to teach and the weapon category prerequisite for the art. 
+      teachArt: the ID of the art to teach in Original Data.
+      reqCategory*: the weapon category the user must be able to use at least one of in order to use the item (0: weapons, 1: bows, 2: magic)
+      staffReq*: true or false, are staff users also allowed to learn this combat art?
+      *Optional parameters. If you leave off both optional parameters, then there is no prerequisite and any unit can learn the art.
+      Example: {teachArt:8, reqCategory:2, staffReq:true} allows units who can use a magic type to learn the combat art with ID 8. Staff users are also eligible.
+
 PLUGIN CUSTOMIZATION
 There are some elements of this plugin that can be modified. For example, you can modify the name of the combat arts unit command.
 To do this, you need to open the file config.js, you can use any text editor like Notepad.

--- a/Combat Art/ca-itemteach.js
+++ b/Combat Art/ca-itemteach.js
@@ -1,0 +1,228 @@
+/**
+ * Addition by Repeat.
+ * Adds support for custom items that teach combat arts.
+ * 
+ * Keyword: CAItem
+ * Custom parameters: 
+ *  * teachArt: ID of the original data of the combat art to teach.
+ *  * reqCategory: ID of weapon category the item is usable by (0: weapons, 1: bows, 2: magic)
+ *  * staffReq: true/false, does the ability to use a staff enable the user to use the item? Defaults to false if left off
+ * Ex: {teachArt:8, reqCategory:1, staffReq:true} for the Combat Art with ID 8 to only be usable by archers and/or staff users.
+ */
+
+var CAItemStrings = {
+    KEYWORD: 'CAItem',
+    ITEMNAME: 'Combat Art Scroll',
+    TEACHES: 'Teaches',
+    PREREQ: 'Prereq'
+};
+
+(function () {
+    var alias1 = ItemControl.isItemUsable;
+    ItemControl.isItemUsable = function (unit, item) {
+        var result = alias1.call(this, unit, item);
+        if (result) {
+            if (item.getCustomKeyword() === CAItemStrings.KEYWORD && typeof item.custom.teachArt === 'number') {
+                if (ItemControl.unitMeetsWeaponTypeRequirement(unit.getClass(), item.custom.reqCategory, item.custom.staffReq)) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        return result;
+    };
+
+    var alias2 = ItemPackageControl.getCustomItemSelectionObject;
+    ItemPackageControl.getCustomItemSelectionObject = function (item, keyword) {
+        if (keyword === CAItemStrings.KEYWORD) {
+            return CombatArtItemSelection;
+        }
+
+        return alias2.call(this, item, keyword);
+    };
+
+    var alias3 = ItemPackageControl.getCustomItemAvailabilityObject;
+    ItemPackageControl.getCustomItemAvailabilityObject = function (item, keyword) {
+        if (keyword === CAItemStrings.KEYWORD) {
+            return CombatArtItemAvailability;
+        }
+        return alias3.call(this, item, keyword);
+    };
+
+    var alias4 = ItemPackageControl.getCustomItemUseObject;
+    ItemPackageControl.getCustomItemUseObject = function (item, keyword) {
+        if (keyword === CAItemStrings.KEYWORD) {
+            return CombatArtItemUse;
+        }
+        return alias4.call(this, item, keyword);
+    };
+
+    var alias5 = ItemPackageControl.getCustomItemInfoObject;
+    ItemPackageControl.getCustomItemInfoObject = function (item, keyword) {
+        if (keyword === CAItemStrings.KEYWORD) {
+            return CombatArtItemInfo;
+        }
+        return alias5.call(this, item, keyword);
+    };
+
+})();
+
+var CombatArtItemSelection = defineObject(BaseItemSelection, {});
+var CombatArtItemInfo = defineObject(BaseItemInfo, {
+    _combatArt: null,
+    _weaponTypeList: null,
+    _hasStaffReq: false,
+
+    drawItemInfoCycle: function (x, y) {
+        ItemInfoRenderer.drawKeyword(x, y, CAItemStrings.ITEMNAME);
+        y += ItemInfoRenderer.getSpaceY();
+
+        // cached for performance
+        if (!this._combatArt) {
+            var id = this._item.custom.teachArt;
+            var combatArt = root.getBaseData().getOriginalDataList(CombatArtSettings.TAB_COMBATART).getDataFromId(id);
+            this._combatArt = combatArt;
+
+            if (!this._weaponTypeList && typeof this._item.custom.reqCategory === 'number') {
+                this._weaponTypeList = root.getBaseData().getWeaponTypeList(this._item.custom.reqCategory);
+            }
+
+            if (this._item.custom.staffReq) {
+                this._hasStaffReq = true;
+            }
+        }
+
+        this._drawName(x, y);
+
+        y += ItemInfoRenderer.getSpaceY();
+
+        if (this._weaponTypeList || this._hasStaffReq) {
+            this._drawReqs(x, y);
+        }
+    },
+
+    getInfoPartsCount: function () {
+        var hasReqs = typeof this._item.custom.reqCategory === 'number' || this._item.custom.staffReq;
+
+        return hasReqs ? 3 : 2;
+    },
+
+    _drawName: function (x, y) {
+        var textui = this.getWindowTextUI();
+        var color = textui.getColor();
+        var font = textui.getFont();
+
+        ItemInfoRenderer.drawKeyword(x, y, CAItemStrings.TEACHES);
+        x += ItemInfoRenderer.getSpaceX() + 16;
+        TextRenderer.drawKeywordText(x, y, this._combatArt.getName(), -1, color, font);
+    },
+
+    _drawReqs: function (x, y) {
+        ItemInfoRenderer.drawKeyword(x, y, CAItemStrings.PREREQ);
+        x += ItemInfoRenderer.getSpaceX() + 16;
+
+        if (this._weaponTypeList) {
+            for (var i = 0; i < this._weaponTypeList.getCount(); i++) {
+                var handle = this._weaponTypeList.getDataFromId(i).getIconResourceHandle();
+                GraphicsRenderer.drawImage(x, y, handle, GraphicsType.ICON);
+                x += GraphicsFormat.ICON_WIDTH;
+            }
+        }
+
+        if (this._hasStaffReq) {
+            var handle = root.getBaseData().getWeaponTypeList(3).getDataFromId(0).getIconResourceHandle();
+            GraphicsRenderer.drawImage(x, y, handle, GraphicsType.ICON);
+        }
+    }
+}
+);
+
+var CombatArtItemAvailability = defineObject(BaseItemAvailability, {
+    isItemAvailableCondition: function (unit, item) {
+        if (typeof item.custom.reqCategory !== 'number') {
+            return true;
+        }
+
+        var able = ItemControl.unitMeetsWeaponTypeRequirement(unit.getClass(), item.custom.reqCategory, item.custom.staffReq);
+
+        return able;
+    }
+});
+
+// This is largely a duplication of ca-eventcommand's effort.
+// Luckily I can reuse its noticeView at least.
+var CombatArtItemUse = defineObject(BaseItemUse, {
+    _unit: null,
+    _combatArt: null,
+    _noticeView: null,
+    _keyword: '',
+
+    enterMainUseCycle: function (itemUseParent) {
+        var itemTargetInfo = itemUseParent.getItemTargetInfo();
+        var item = itemTargetInfo.item;
+        this._unit = itemTargetInfo.targetUnit;
+        this._keyword = item.custom.teachArt;
+
+        this._setCombatArt();
+
+        this._noticeView = createObject(CombatArtNoticeView);
+        this._noticeView.setViewText(this._unit, this._combatArt, "Add");
+
+        return EnterResult.OK;
+    },
+
+    moveMainUseCycle: function () {
+        if (this._noticeView.moveNoticeView() !== MoveResult.CONTINUE) {
+            return MoveResult.END;
+        }
+
+        return MoveResult.CONTINUE;
+    },
+
+    drawMainUseCycle: function () {
+        var x = LayoutControl.getCenterX(-1, this._noticeView.getNoticeViewWidth());
+        var y = LayoutControl.getCenterY(-1, this._noticeView.getNoticeViewHeight());
+
+        this._noticeView.drawNoticeView(x, y);
+    },
+
+    _setCombatArt: function () {
+        var id;
+        id = this._keyword;
+
+        var combatArt = root.getBaseData().getOriginalDataList(CombatArtSettings.TAB_COMBATART).getDataFromId(id);
+        this._combatArt = combatArt;
+
+        CombatArtEvent.addCombatArt(combatArt, this._unit);
+    }
+});
+
+/**
+ * Loops through the unit's class's usable weapon types and see if any matches the required weapon category.
+ * @param {obj} unit
+ * @param {int} category - number from 0 to 2 (weapon, magic, bow)
+ * @param {boolean} hasStaffReq - if true, staff is included in the prerequisites
+ */
+ItemControl.unitMeetsWeaponTypeRequirement = function (cls, category, hasStaffReq) {
+    if (hasStaffReq && (cls.getClassOption() & ClassOptionFlag.WAND)) {
+        return true;
+    }
+
+    if (typeof category !== 'number') {
+        return true;
+    }
+
+    var refList = cls.getEquipmentWeaponTypeReferenceList();
+    var i;
+    var found = false;
+    var count = refList.getTypeCount();
+
+    for (i = 0; i < count; i++) {
+        if (refList.getTypeData(i).getWeaponCategoryType() === category) {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+};

--- a/HP Cost for Weapons and Items/hpcost-control.js
+++ b/HP Cost for Weapons and Items/hpcost-control.js
@@ -19,6 +19,9 @@ var HPCostControl = {
     getTimesPayCost: function (unit, item) {
         var lifeCost = item.custom.lifeCost;
         var maxUseCount = Math.floor(unit.getHp() / lifeCost);
+        if (unit.getHp() === lifeCost) {
+            maxUseCount = 0;
+        }
 
         return maxUseCount;
     },
@@ -34,7 +37,7 @@ var HPCostControl = {
         if (this.hasCost(item)) {
             var currentHP = unit.getHp();
             var lifeCost = item.custom.lifeCost;
-            unit.setHp(currentHp - lifeCost);
+            unit.setHp(currentHP - lifeCost);
         }
     }
 

--- a/Weapons and Items as Original Data/$readme.txt
+++ b/Weapons and Items as Original Data/$readme.txt
@@ -1,7 +1,7 @@
 Weapons and Items as Original Data
 By Goinza
-Version 2.1
-May 26, 2020
+Version 2.2
+March 31, 2022
 
 This plugin allows the creation of Original Data entries that act as weapons or items.
 This means that you can, for example, make a magic system where the magic is not in the inventory, but instead it is from Original Data entries.
@@ -14,11 +14,17 @@ To make this system work, you need to do the following for each spell/weapon/ite
     -Change the value in Value 1 to set the level requirement. If you leave it at zero, there is no level requirement.
     -You can also add the following requirements in the Multiple Data window: units and classes. If a unit that gains a level meets at least one of the requirements,
         on top of already meeting the level requirement, then it will be able to use that weapon or item.
+    -Original data needs to have keyword "Spell"
 
 IMPORTANT: To make this work, you need to create a Execute Script event of the type Execute Code and write the next line of code:
     MagicAttackControl.setSpellsAllUnits();
 KNOWN ISSUE: This system doesn't work on guest units. However, it does work for event guest units.
 IF YOU USE GUEST UNITS THAT ARE NOT CREATED THROUGH EVENTS THE GAME WILL CRASH
+
+GAME CRASH POTENTIAL: In Database > Config, make sure "Skip weapon select menu when only have 1 weapon" is NOT checked. This option does not consider Weapon and Items as Original Data.
+    The problems:
+	- If you have 1 normal weapon, the game will incorrectly ignore any Original Data weapons and skip the weapon select menu.
+	- If you have no normal weapons but do have Original Data weapons, the game will crash when trying to show the weapon select menu.
 
 CONFIGURE SETTINGS
 You can change some options of this plugin by opening the _config.js file with a text editor like Notepad.
@@ -36,6 +42,16 @@ EVENT COMMAND TO ADD NEW WEAPONS OR ITEMS TO AN UNIT
 You can create a Execute Script event with the type "Call Event Command". To make this work, you need to set the Object Name to "AddSpell".
 Finally, you need to specifiy in the Original Data tab the unit that will receive the new weapon/item,
 and also change the Value 1 to the ID of the Original Data that will be added to the unit.
+
+CREATE ITEM THAT GRANTS THE USER A SPELL
+You can create an item that will teach a unit a specific spell if the unit has the ability to use any magic type.
+    - Create an item of type Custom with the keyword "SpellItem".
+    - Add custom parameters to define the weapon or item to give to the user and the prerequisites to use the teaching item. 
+      teachSpell: the ID of the weapon or item to teach in Original Data.
+      reqCategory*: the weapon category the user must be able to use at least one of in order to use the item (0: weapons, 1: bows, 2: magic)
+      staffReq*: true or false, are staff users also allowed to use this item?
+      *Optional parameters. If you leave off both optional parameters, then there is no prerequisite and any unit can use the item.
+      Example: {teachSpell:2, reqCategory:1, staffReq:true} allows units who can use bows to learn the spell with ID 2. Staff users are also eligible.
 
 BALLISTA
 You can also make a unit use a specific weapon in a specific tile, like for example a ballista that is fixed in a tile and can be used by archers.

--- a/Weapons and Items as Original Data/error-skill.js
+++ b/Weapons and Items as Original Data/error-skill.js
@@ -29,3 +29,9 @@ function throwError051(originalData) {
     root.msg(message);
     root.endGame();
 }
+
+function throwError052 () {
+    var message = "Error 52." + '\n' + "Please disable the following config option in Database -> Config:" + '\n' + '\"Skip weapon select menu when only have 1 weapon\"';
+    root.msg(message);
+    root.endGame();
+}

--- a/Weapons and Items as Original Data/magic-alias.js
+++ b/Weapons and Items as Original Data/magic-alias.js
@@ -227,19 +227,18 @@
     var alias9 = UnitRangePanel.getUnitAttackRange;
     UnitRangePanel.getUnitAttackRange = function(unit) {
         var obj = alias9.call(this, unit);
-        if (unit.getUnitType() != UnitType.PLAYER) {
-            var spells = MagicAttackControl.getAttackSpells(unit);
-            var weapon;
-            for (var i=0; i<spells.length; i++) {
-                weapon = spells[i];
-                rangeMetrics = this._getRangeMetricsFromItem(unit, weapon);
-                if (rangeMetrics != null) {
-                    if (rangeMetrics.startRange < obj.startRange) {
-                        obj.startRange = rangeMetrics.startRange;
-                    }
-                    if (rangeMetrics.endRange > obj.endRange) {
-                        obj.endRange = rangeMetrics.endRange;
-                    }
+
+        var spells = MagicAttackControl.getAttackSpells(unit);
+        var weapon;
+        for (var i=0; i<spells.length; i++) {
+            weapon = spells[i];
+            rangeMetrics = this._getRangeMetricsFromItem(unit, weapon);
+            if (rangeMetrics != null) {
+                if (rangeMetrics.startRange < obj.startRange) {
+                    obj.startRange = rangeMetrics.startRange;
+                }
+                if (rangeMetrics.endRange > obj.endRange) {
+                    obj.endRange = rangeMetrics.endRange;
                 }
             }
         }

--- a/Weapons and Items as Original Data/magic-control.js
+++ b/Weapons and Items as Original Data/magic-control.js
@@ -87,6 +87,11 @@ var MagicAttackControl = {
 
     setSpellsAllUnits: function() {
         var groupArray = [];
+
+        if (DataConfig.isWeaponSelectSkippable()) {
+            throwError052();
+        }
+
         groupArray.push(PlayerList.getAliveList());
         groupArray.push(EnemyList.getAliveList());
         groupArray.push(AllyList.getAliveList());
@@ -158,7 +163,6 @@ var MagicAttackControl = {
             item = originalData.getOriginalContent().getItem();
             this._addOriginalData(unit, originalData);
             this._addItem(unit, item);
-            this._notifyEvent(unit, item);
         }      
     },
 
@@ -279,14 +283,5 @@ var MagicAttackControl = {
         else {
             unit.custom.spellsSupport.push(copyItem);
         }
-    },
-
-    _notifyEvent: function(unit, item) {
-        var dynamicEvent = createObject(DynamicEvent);
-        var generator = dynamicEvent.acquireEventGenerator();
-        var message = "Learnt " + item.getName();
-        generator.stillMessageUnit(message, unit);
-        dynamicEvent.executeDynamicEvent();
     }
-    
 }

--- a/Weapons and Items as Original Data/magic-itemteach.js
+++ b/Weapons and Items as Original Data/magic-itemteach.js
@@ -1,0 +1,221 @@
+/**
+ * Addition by Repeat.
+ * Adds support for custom items that teach spells.
+ * 
+ * Keyword: SpellItem
+ * Custom parameters: 
+ *  * ID of the original data of the spell to teach.
+ *  * reqCategory: ID of weapon category the item is usable by (0: weapons, 1: bows, 2: magic)
+ *  * staffReq: true/false, does the ability to use a staff enable the user to use the item? Defaults to false if left off
+ * Ex: {teachSpell:0, reqCategory:2, staffReq:true} for spell with ID 0 to only be usable by mages and/or staff users.
+ */
+
+var SpellItemStrings = {
+    KEYWORD: 'SpellItem',
+    ITEMNAME: 'Spell Scroll',
+    TEACHES: 'Teaches',
+    PREREQ: 'Prereq'
+};
+
+(function () {
+    var alias1 = ItemControl.isItemUsable;
+    ItemControl.isItemUsable = function (unit, item) {
+        var result = alias1.call(this, unit, item);
+        if (result) {
+            if (item.getCustomKeyword() === SpellItemStrings.KEYWORD && typeof item.custom.teachSpell === 'number') {
+                if (ItemControl.unitMeetsWeaponTypeRequirement(unit.getClass(), item.custom.reqCategory, item.custom.staffReq)) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        return result;
+    };
+
+    var alias2 = ItemPackageControl.getCustomItemSelectionObject;
+    ItemPackageControl.getCustomItemSelectionObject = function (item, keyword) {
+        if (keyword === SpellItemStrings.KEYWORD) {
+            return SpellItemSelection;
+        }
+
+        return alias2.call(this, item, keyword);
+    };
+
+    var alias3 = ItemPackageControl.getCustomItemAvailabilityObject;
+    ItemPackageControl.getCustomItemAvailabilityObject = function (item, keyword) {
+        if (keyword === SpellItemStrings.KEYWORD) {
+            return SpellItemAvailability;
+        }
+        return alias3.call(this, item, keyword);
+    };
+
+    var alias4 = ItemPackageControl.getCustomItemUseObject;
+    ItemPackageControl.getCustomItemUseObject = function (item, keyword) {
+        if (keyword === SpellItemStrings.KEYWORD) {
+            return SpellItemUse;
+        }
+        return alias4.call(this, item, keyword);
+    };
+
+    var alias5 = ItemPackageControl.getCustomItemInfoObject;
+    ItemPackageControl.getCustomItemInfoObject = function (item, keyword) {
+        if (keyword === SpellItemStrings.KEYWORD) {
+            return SpellItemInfo;
+        }
+        return alias5.call(this, item, keyword);
+    };
+})();
+
+var SpellItemSelection = defineObject(BaseItemSelection, {});
+var SpellItemInfo = defineObject(BaseItemInfo, {
+    _spell: null,
+    _weaponTypeList: null,
+    _hasStaffReq: false,
+
+    drawItemInfoCycle: function (x, y) {
+        ItemInfoRenderer.drawKeyword(x, y, SpellItemStrings.ITEMNAME);
+        y += ItemInfoRenderer.getSpaceY();
+
+        // cached for performance
+        if (!this._spell) {
+            var id = this._item.custom.teachSpell;
+            var spell = root.getBaseData().getOriginalDataList(SpellsConfig.ORIGINAL_DATA_TAB).getDataFromId(id);
+            this._spell = spell;
+
+            if (!this._weaponTypeList && typeof this._item.custom.reqCategory === 'number') {
+                this._weaponTypeList = root.getBaseData().getWeaponTypeList(this._item.custom.reqCategory);
+            }
+
+            if (this._item.custom.staffReq) {
+                this._hasStaffReq = true;
+            }
+        }
+
+        this._drawName(x, y);
+
+        y += ItemInfoRenderer.getSpaceY();
+
+        if (this._weaponTypeList || this._hasStaffReq) {
+            this._drawReqs(x, y);
+        }
+    },
+
+    getInfoPartsCount: function () {
+        var hasReqs = typeof this._item.custom.reqCategory === 'number' || this._item.custom.staffReq;
+
+        return hasReqs ? 3 : 2;
+    },
+
+    _drawName: function (x, y) {
+        var textui = this.getWindowTextUI();
+        var color = textui.getColor();
+        var font = textui.getFont();
+
+        ItemInfoRenderer.drawKeyword(x, y, SpellItemStrings.TEACHES);
+        x += ItemInfoRenderer.getSpaceX() + 16;
+        TextRenderer.drawKeywordText(x, y, this._spell.getName(), -1, color, font);
+    },
+
+    _drawReqs: function (x, y) {
+        ItemInfoRenderer.drawKeyword(x, y, SpellItemStrings.PREREQ);
+        x += ItemInfoRenderer.getSpaceX() + 16;
+
+        if (this._weaponTypeList) {
+            for (var i = 0; i < this._weaponTypeList.getCount(); i++) {
+                var handle = this._weaponTypeList.getDataFromId(i).getIconResourceHandle();
+                GraphicsRenderer.drawImage(x, y, handle, GraphicsType.ICON);
+                x += GraphicsFormat.ICON_WIDTH;
+            }
+        }
+
+        if (this._hasStaffReq) {
+            var handle = root.getBaseData().getWeaponTypeList(3).getDataFromId(0).getIconResourceHandle();
+            GraphicsRenderer.drawImage(x, y, handle, GraphicsType.ICON);
+        }
+    }
+}
+);
+
+var SpellItemAvailability = defineObject(BaseItemAvailability, {
+    isItemAvailableCondition: function (unit, item) {
+        var able = ItemControl.unitMeetsWeaponTypeRequirement(unit.getClass(), item.custom.reqCategory, item.custom.staffReq);
+
+        return able;
+    }
+});
+
+// This is largely a duplication of MagicEventCommand's effort.
+// Luckily I can reuse its noticeView at least.
+var SpellItemUse = defineObject(BaseItemUse, {
+    _unit: null,
+    _noticeView: null,
+    _spell: null,
+    _keyword: '',
+
+    enterMainUseCycle: function (itemUseParent) {
+        var itemTargetInfo = itemUseParent.getItemTargetInfo();
+        var item = itemTargetInfo.item;
+        this._unit = itemTargetInfo.targetUnit;
+        this._keyword = item.custom.teachSpell;
+
+        this._setSpell();
+
+        this._noticeView = createObject(SpellNoticeView);
+        this._noticeView.setViewText(this._unit, this._spell);
+
+        return EnterResult.OK;
+    },
+
+    moveMainUseCycle: function () {
+        if (this._noticeView.moveNoticeView() !== MoveResult.CONTINUE) {
+            return MoveResult.END;
+        }
+
+        return MoveResult.CONTINUE;
+    },
+
+    drawMainUseCycle: function () {
+        var x = LayoutControl.getCenterX(-1, this._noticeView.getNoticeViewWidth());
+        var y = LayoutControl.getCenterY(-1, this._noticeView.getNoticeViewHeight());
+
+        this._noticeView.drawNoticeView(x, y);
+    },
+
+    _setSpell: function () {
+        var id = this._keyword;
+        var spell = root.getBaseData().getOriginalDataList(SpellsConfig.ORIGINAL_DATA_TAB).getDataFromId(id);
+        this._spell = spell;
+
+        MagicAttackControl.addSpell(this._unit, spell);
+    }
+});
+
+/**
+ * Loops through the unit's class's usable weapon types and see if any matches the required weapon category.
+ * @param {obj} unit
+ * @param {int} category - number from 0 to 2 (weapon, magic, bow)
+ * @param {boolean} hasStaffReq - if true, staff is included in the prerequisites
+ */
+ItemControl.unitMeetsWeaponTypeRequirement = function (cls, category, hasStaffReq) {
+    if (hasStaffReq && (cls.getClassOption() & ClassOptionFlag.WAND)) {
+        return true;
+    }
+
+    if (typeof category !== 'number') {
+        return true;
+    }
+
+    var refList = cls.getEquipmentWeaponTypeReferenceList();
+    var i;
+    var found = false;
+    var count = refList.getTypeCount();
+
+    for (i = 0; i < count; i++) {
+        if (refList.getTypeData(i).getWeaponCategoryType() === category) {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+};


### PR DESCRIPTION
Main focus of PR is adding items that teach spells (Weapons and Items as Original Data) and items that teach Combat Arts.
Also in this PR: 
- added an error state for a particular Config option that breaks Weapons & Items as Original Data
- updated readmes with info about how to use the new teaching items and a warning about the above error state
- added missing info to readmes, like the keyword for Weapons and Items as Original Data being "Spell" (previously did not say so outside of an error message)
- refactoring to remove/refactor undesirable or outdated features
- fixes to HP Cost plugin for a typo and a logic error. Note that this logic error actually didn't matter, since getTimesPayCost is never called and its functionality is repeatedly duplicated in hpcost-alias.js. Worth exploring at some other time